### PR TITLE
fix for bundle install alert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,3 @@ ENV HOME /app
 
 # executing bundle install
 COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,4 +58,4 @@ volumes:
   data:
     driver: local
   redis-data:
-      driver: local
+    driver: local

--- a/qs
+++ b/qs
@@ -70,6 +70,9 @@ create_project() {
   echoing "Exec rails new with postgresql and webpack"
   bundle_exec rails new . -f -d=$db_option$front_option$test_option
 
+  echoing "Exec Bundle Update for alerts"
+  bundle_cmd update
+
   echoing "Update config/database.yml"
   mv database.yml config/database.yml
 

--- a/qs
+++ b/qs
@@ -79,6 +79,11 @@ create_project() {
   echoing "Exec db create"
   bundle_exec rails db:create
 
+  if [ " --webpack" == "$front_option" ]; then
+    echoing "Exec webpacker:install"
+	bundle_exec rails webpacker:install
+  fi
+
   echoing "docker-compose up"
   compose_up $app
 


### PR DESCRIPTION
`bundle install` 後に依存でエラーになってしますので `bundle update` で回避する。

最近出るようになったらしいので、rails起因の問題のようである。

mysqlとpostgresqlにてwelcomeページまでの動作確認完了。

あと、 `webpack:install` が抜けてた。いつからなのだろうか。。。